### PR TITLE
Enable GPU acceleration support for the feature extractor (#20)

### DIFF
--- a/text_localization_environment/TextLocEnv.py
+++ b/text_localization_environment/TextLocEnv.py
@@ -283,10 +283,11 @@ class TextLocEnv(gym.Env):
         return cropped.resize((224, 224), LANCZOS)
 
     def compute_state(self):
+        history = np.array(self.history).flatten()
+        features = self.extract_features().array
         if self.gpu_id != -1:
-            return np.concatenate((cuda.to_cpu(self.extract_features().array), np.array(self.history).flatten()))
-        else:
-            return np.concatenate((self.extract_features().array, np.array(self.history).flatten()))
+            features = cuda.to_cpu(features)
+        return np.concatenate(features, history)
 
     def extract_features(self):
         """Extract features from the image using the VGG16 network"""

--- a/text_localization_environment/TextLocEnv.py
+++ b/text_localization_environment/TextLocEnv.py
@@ -46,6 +46,9 @@ class TextLocEnv(gym.Env):
         self.image_paths = image_paths
         self.true_bboxes = true_bboxes
 
+        if self.gpu_id != -1:
+            self.feature_extractor.to_gpu(self.gpu_id)
+
         self.seed()
         self.reset()
 
@@ -280,7 +283,10 @@ class TextLocEnv(gym.Env):
         return cropped.resize((224, 224), LANCZOS)
 
     def compute_state(self):
-        return np.concatenate((self.extract_features().array, np.array(self.history).flatten()))
+        if self.gpu_id != -1:
+            return np.concatenate((cuda.to_cpu(self.extract_features().array), np.array(self.history).flatten()))
+        else:
+            return np.concatenate((self.extract_features().array, np.array(self.history).flatten()))
 
     def extract_features(self):
         """Extract features from the image using the VGG16 network"""


### PR DESCRIPTION
Closes #20 

this allows for the feature extraction to run on the gpu. Note that currently this is being done by copying the resulting feature array from gpu to cpu memory for the state computation. We might also be able to put the history onto the gpu memory but im not sure if that will help with performance at all.